### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/assets/images/app-store.svgZone.Identifier
+++ b/app/assets/images/app-store.svgZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/card-jcb.gifZone.Identifier
+++ b/app/assets/images/card-jcb.gifZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/card-mastercard.gifZone.Identifier
+++ b/app/assets/images/card-mastercard.gifZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/card-visa.gifZone.Identifier
+++ b/app/assets/images/card-visa.gifZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/comment.pngZone.Identifier
+++ b/app/assets/images/comment.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/flag.pngZone.Identifier
+++ b/app/assets/images/flag.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-footer.pngZone.Identifier
+++ b/app/assets/images/furima-footer.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-header01.pngZone.Identifier
+++ b/app/assets/images/furima-header01.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-header02.pngZone.Identifier
+++ b/app/assets/images/furima-header02.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-intro01.pngZone.Identifier
+++ b/app/assets/images/furima-intro01.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-intro02.pngZone.Identifier
+++ b/app/assets/images/furima-intro02.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-intro03.pngZone.Identifier
+++ b/app/assets/images/furima-intro03.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-intro04.pngZone.Identifier
+++ b/app/assets/images/furima-intro04.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-intro05.pngZone.Identifier
+++ b/app/assets/images/furima-intro05.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-intro06.pngZone.Identifier
+++ b/app/assets/images/furima-intro06.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-logo-color.pngZone.Identifier
+++ b/app/assets/images/furima-logo-color.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/furima-logo-white.pngZone.Identifier
+++ b/app/assets/images/furima-logo-white.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/google-play.pngZone.Identifier
+++ b/app/assets/images/google-play.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/icon_camera.pngZone.Identifier
+++ b/app/assets/images/icon_camera.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/item-sample.pngZone.Identifier
+++ b/app/assets/images/item-sample.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/search.pngZone.Identifier
+++ b/app/assets/images/search.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/assets/images/star.pngZone.Identifier
+++ b/app/assets/images/star.pngZone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\kawaa\Downloads\furima_ëfçﬁ (1).zip

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,10 @@ class ItemsController < ApplicationController
   # before_action :move_to_new, except: [:new]
   before_action :authenticate_user!, only: [:new, :edit, :destroy]
   def index
-    # @item = Item.all
+    # binding.pry
+    @items = Item.all
+    charge_id_names= { 2 => '着払い(購入者負担)', 3 => '送料込み(出品者負担)' } 
+    @charge_id_names = charge_id_names
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,6 +6,7 @@ class ItemsController < ApplicationController
     @items = Item.all
     charge_id_names= { 2 => '着払い(購入者負担)', 3 => '送料込み(出品者負担)' } 
     @charge_id_names = charge_id_names
+    @sold_out_items = calculate_sold_out_items(@items)
   end
 
   def new
@@ -34,5 +35,9 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :explanation, :category_id, :condition_id, :charge_id, :area_id, :shippingday_id, :price,
                                  :image).merge(user_id: current_user.id)
+  end
+
+  def calculate_sold_out_items(items)
+    items.select { |item| item.sold_out? }
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
   # before_action :move_to_new, except: [:new]
   before_action :authenticate_user!, only: [:new, :edit, :destroy]
   def index
-    # binding.pry
     @items = Item.all
     charge_id_names= { 2 => '着払い(購入者負担)', 3 => '送料込み(出品者負担)' } 
     @charge_id_names = charge_id_names

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
     @items = Item.all
     charge_id_names= { 2 => '着払い(購入者負担)', 3 => '送料込み(出品者負担)' } 
     @charge_id_names = charge_id_names
-    @sold_out_items = calculate_sold_out_items(@items)
+    # @sold_out_items = calculate_sold_out_items(@items)
   end
 
   def new
@@ -37,7 +37,7 @@ class ItemsController < ApplicationController
                                  :image).merge(user_id: current_user.id)
   end
 
-  def calculate_sold_out_items(items)
-    items.select { |item| item.sold_out? }
-  end
+  # def calculate_sold_out_items(items)
+  #   items.select { |item| item.sold_out? }
+  # end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,22 +126,16 @@
     <div class="subtitle" >
       新規投稿商品
     </div>
-    <ul class='item-lists'>
-      <!-- <li class='list'>
-        <%= link_to "#" do %>
-          <div class='item-img-content'>
-            <%= image_tag "item-sample.png", class: "item-img" %>
-            <div class='sold-out'>
+    <ul class='item-lists'>       
+        <%# 売れたらsold outを表示(あとで消す) %>
+            <!-- <div class='sold-out'>
               <span>Sold Out!!</span>
             </div>
-          </div>
-        <% end %>
-        <%# 商品が売れていればsold outを表示しましょう %>
-        <%# //商品が売れていればsold outを表示しましょう %>
-      </li> -->
+          </div> -->
           <% if @items.present? %>
            <% @items.reverse_each do |item| %>
               <li class='list'>
+                <%= link_to "#" do %>
                 <%= image_tag item.image, class: "item-img" %>
                 <div class='item-info'>
                   <h3 class='item-name'>
@@ -155,6 +149,7 @@
                     </div>
                   </div>
                 </div>
+                <% end %>
               </li>
             <% end %>
           <% else %>
@@ -176,13 +171,6 @@
               </div>
             </li>
           <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -157,7 +157,7 @@
                 </div>
               </li>
             <% end %>
-          <% elsif @items.sold_out? %>
+          <% elsif @sold_out_items.any? %>
             <% @items.each do |item| %>
               <li class='list'>
                 <%= image_tag item.image %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,7 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-      <li class='list'>
+      <!-- <li class='list'>
         <%= link_to "#" do %>
           <div class='item-img-content'>
             <%= image_tag "item-sample.png", class: "item-img" %>
@@ -138,7 +138,7 @@
         <% end %>
         <%# 商品が売れていればsold outを表示しましょう %>
         <%# //商品が売れていればsold outを表示しましょう %>
-      </li>
+      </li> -->
           <% if @items.present? %>
            <% @items.reverse_each do |item| %>
               <li class='list'>
@@ -155,23 +155,6 @@
                     </div>
                   </div>
                 </div>
-              </li>
-            <% end %>
-          <% elsif @sold_out_items.any? %>
-            <% @items.each do |item| %>
-              <li class='list'>
-                <%= image_tag item.image %>
-                <div class='item-info'>
-                  <h3 class='item-name'>
-                    <%= item.name %>
-                  </h3>
-                  <div class='item-price'>
-                    <span><%= item.price %>円<br><%= item.charge_id %></span>
-                    <div class='star-btn'>
-                      <%= image_tag "star.png", class:"star-icon" %>
-                      <span class='star-count'>0</span>
-                    </div>
-                  </div>
               </li>
             <% end %>
           <% else %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,54 +128,74 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
         <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
-          </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-img-content'>
+            <%= image_tag "item-sample.png", class: "item-img" %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
             </div>
           </div>
-        </div>
         <% end %>
+        <%# 商品が売れていればsold outを表示しましょう %>
+        <%# if文 % "if @items.present">
+         <%# <% @items.each do |item| %> 
+         <!-- <%= image_tag item.image %>
+                <div class='item-info'>
+                  <h3 class='item-name'>
+                    <%= item.name %>
+                  </h3>
+                  <div class='item-price'>
+                    <span><%= item.price %>円<br><%= @charge_id_names[item.charge_id] %></span>
+                    <div class='star-btn'>
+                      <%= image_tag "star.png", class:"star-icon" %>
+                      <span class='star-count'>0</span> -->
+        <%# //商品が売れていればsold outを表示しましょう %>
       </li>
+          
+          
+          <% if @items.present? %>
+            <li class='list'>
+              <% @items.each do |item| %>
+                <%= image_tag item.image %>
+                <div class='item-info'>
+                  <h3 class='item-name'>
+                    <%= item.name %>
+                  </h3>
+                  <div class='item-price'>
+                    <span><%= item.price %>円<br><%= @charge_id_names[item.charge_id] %></span>
+                    <div class='star-btn'>
+                      <%= image_tag "star.png", class:"star-icon" %>
+                      <span class='star-count'>0</span>
+                    </div>
+                  </div>
+                </div>
+              <% end %>
+            </li>
+          <% else %>
+            <li class='list'>
+              <%= link_to '#' do %>
+                <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
+              <% end %>
+              <div class='item-info'>
+                <h3 class='item-name'>
+                  商品を出品してね！
+                </h3>
+                <div class='item-price'>
+                  <span>99999999円<br>(税込み)</span>
+                  <div class='star-btn'>
+                    <%= image_tag "star.png", class:"star-icon" %>
+                    <span class='star-count'>0</span>
+                  </div>
+                </div>
+              </div>
+            </li>
+          <% end %>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
+      
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,7 +127,6 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
       <li class='list'>
         <%= link_to "#" do %>
           <div class='item-img-content'>
@@ -138,26 +137,12 @@
           </div>
         <% end %>
         <%# 商品が売れていればsold outを表示しましょう %>
-        <%# if文 % "if @items.present">
-         <%# <% @items.each do |item| %> 
-         <!-- <%= image_tag item.image %>
-                <div class='item-info'>
-                  <h3 class='item-name'>
-                    <%= item.name %>
-                  </h3>
-                  <div class='item-price'>
-                    <span><%= item.price %>円<br><%= @charge_id_names[item.charge_id] %></span>
-                    <div class='star-btn'>
-                      <%= image_tag "star.png", class:"star-icon" %>
-                      <span class='star-count'>0</span> -->
         <%# //商品が売れていればsold outを表示しましょう %>
       </li>
-          
-          
           <% if @items.present? %>
-            <li class='list'>
-              <% @items.each do |item| %>
-                <%= image_tag item.image %>
+           <% @items.reverse_each do |item| %>
+              <li class='list'>
+                <%= image_tag item.image, class: "item-img" %>
                 <div class='item-info'>
                   <h3 class='item-name'>
                     <%= item.name %>
@@ -170,8 +155,25 @@
                     </div>
                   </div>
                 </div>
-              <% end %>
-            </li>
+              </li>
+            <% end %>
+          <% elsif @items.sold_out? %>
+            <% @items.each do |item| %>
+              <li class='list'>
+                <%= image_tag item.image %>
+                <div class='item-info'>
+                  <h3 class='item-name'>
+                    <%= item.name %>
+                  </h3>
+                  <div class='item-price'>
+                    <span><%= item.price %>円<br><%= item.charge_id %></span>
+                    <div class='star-btn'>
+                      <%= image_tag "star.png", class:"star-icon" %>
+                      <span class='star-count'>0</span>
+                    </div>
+                  </div>
+              </li>
+            <% end %>
           <% else %>
             <li class='list'>
               <%= link_to '#' do %>


### PR DESCRIPTION
#What
商品一覧表示機能
#Why
画像・商品名・価格・配送料の負担の表示設定
商品なし時にダミーの表示､売却済み商品画像に「sold out」の文字
売り切れ時の構文修正


- [ ]  商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/78fae7ea79e96ae5ed9a28cecce10902
- [ ]  商品のデータがある場合は、商品が一覧で表示されている動画（2つ以上の商品が出品されている状態を撮影してください。表示順を確かめるためです）
https://gyazo.com/05f214ad9a3475efc2404b1b57ca2b9c